### PR TITLE
fix translation of `by`

### DIFF
--- a/admin_numeric_filter/templates/admin/filter_numeric_range.html
+++ b/admin_numeric_filter/templates/admin/filter_numeric_range.html
@@ -8,7 +8,7 @@
             {% endif %}
         {% endfor %}
 
-        <h3>{% blocktrans with filter_title=title %}By {{ filter_title }}{% endblocktrans %}</h3>
+		<h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 
         <div class="admin-numeric-filter-wrapper-group">
             {{ choice.form.as_p }}

--- a/admin_numeric_filter/templates/admin/filter_numeric_single.html
+++ b/admin_numeric_filter/templates/admin/filter_numeric_single.html
@@ -8,7 +8,7 @@
             {% endif %}
         {% endfor %}
 
-        <h3>{% blocktrans with filter_title=title %}By {{ filter_title }}{% endblocktrans %}</h3>
+		<h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 
         {{ choice.form.as_p }}
 

--- a/admin_numeric_filter/templates/admin/filter_numeric_slider.html
+++ b/admin_numeric_filter/templates/admin/filter_numeric_slider.html
@@ -8,7 +8,7 @@
             {% endif %}
         {% endfor %}
 
-        <h3>{% blocktrans with filter_title=title %}By {{ filter_title }}{% endblocktrans %}</h3>
+		<h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 
         <div class="admin-numeric-filter-slider-tooltips">
             <span class="admin-numeric-filter-slider-tooltip-from">{{ choice.value_from }}</span>


### PR DESCRIPTION
Hi there! First of all thanks for the awesome work. I noticed that "by" was not being translated in Django 2.1.7. Adding spaces fixed the issue. 

Thanks!
S

![imagen](https://user-images.githubusercontent.com/4853035/54784524-647da400-4c24-11e9-8264-784f6f46cd62.png)
