### PR TITLE
fix SliderNumericFilter.choices for FloatField

### DIFF
--- a/admin_numeric_filter/admin.py
+++ b/admin_numeric_filter/admin.py
@@ -144,10 +144,8 @@ class SliderNumericFilter(RangeNumericFilter):
             decimals = 0
             step = 1
         elif isinstance(self.field, FloatField):
-            values = self.q.all().values_list(self.parameter_name, flat=True)
-            max_precision = max(str(value)[::-1].find('.') for value in values)
-            decimals = self._get_decimals(max_precision)
-            step = self._get_min_step(max_precision)
+            decimals = self.MAX_DECIMALS
+            step = self._get_min_step(self.MAX_DECIMALS)
         elif isinstance(self.field, DecimalField):
             step = self._get_min_step(self.field.decimal_places)
             decimals = self._get_decimals(self.field.decimal_places)


### PR DESCRIPTION
Hey there, I found three severe issues with the implementation:
- `max(…)` fails with `ValueError`, if `…` is empty
- calculating the precision from the data is not tractable, if you have too much data
- calculating it from the data is not useful, because rounding errors can lead to arbitrarily high precisions (like storing a `1` as `0.9999999999998` for example)

That's why I'd suggest to remove the logic and go with static, but configurable values, instead.