### PR TITLE
Fix minimum as zero case.

### DIFF
--- a/admin_numeric_filter/templates/admin/filter_numeric_slider.html
+++ b/admin_numeric_filter/templates/admin/filter_numeric_slider.html
@@ -10,7 +10,7 @@
 
         <h3>{% blocktrans with filter_title=title %}By {{ filter_title }}{% endblocktrans %}</h3>
 
-        {% if choice.min and choice.max and choice.step %}
+        {% if choice.min or choice.min == 0 and choice.max or choice.max == 0 and choice.step %}
             <div class="admin-numeric-filter-slider-tooltips">
                 <span class="admin-numeric-filter-slider-tooltip-from">{{ choice.value_from }}</span>
                 <span class="admin-numeric-filter-slider-tooltip-to">{{ choice.value_to }}</span>


### PR DESCRIPTION
Fixes #5 

Basically 0 was evaluated as falsy when in this case zero is a valid value for minimum.