### PR TITLE
fix(admin): Handle list input for RangeNumericFilter in Django 5.1

### DIFF
--- a/admin_numeric_filter/admin.py
+++ b/admin_numeric_filter/admin.py
@@ -73,10 +73,14 @@ class RangeNumericFilter(admin.FieldListFilter):
 
         if self.parameter_name + '_from' in params:
             value = params.pop(self.field_path + '_from')
+            if isinstance(value, list):
+                value = value[0]
             self.used_parameters[self.field_path + '_from'] = value
 
         if self.parameter_name + '_to' in params:
             value = params.pop(self.field_path + '_to')
+            if isinstance(value, list):
+                value = value[0]
             self.used_parameters[self.field_path + '_to'] = value
 
     def queryset(self, request, queryset):


### PR DESCRIPTION
Updated RangeNumericFilter to handle list inputs correctly, preventing ['x']” value must be a decimal number in Django 5.1.

https://github.com/lukasvinclav/django-admin-numeric-filter/issues/34